### PR TITLE
Use post over class specific properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "canonicalize": "^1.0.8",
     "chai": "^4.3.4",
     "credentials-context": "^2.0.0",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#use-endpoint-class",
     "ed25519-signature-2018-context": "^1.1.0",
     "ed25519-signature-2020-context": "^1.1.0",
     "jsonld": "^5.2.0",
@@ -28,7 +28,7 @@
     "require-dir": "^1.2.0",
     "uuid": "^8.3.2",
     "varint": "^6.0.0",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
   },
   "devDependencies": {
     "eslint": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "canonicalize": "^1.0.8",
     "chai": "^4.3.4",
     "credentials-context": "^2.0.0",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#use-endpoint-class",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
     "ed25519-signature-2018-context": "^1.1.0",
     "ed25519-signature-2020-context": "^1.1.0",
     "jsonld": "^5.2.0",
@@ -28,7 +28,7 @@
     "require-dir": "^1.2.0",
     "uuid": "^8.3.2",
     "varint": "^6.0.0",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations#add-endpoint-class"
+    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^8.6.0",

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -18,7 +18,7 @@ const {validVc} = require('../credentials');
 
 // only use implementations with `Ed25519 2020` issuers.
 const tag = 'Ed25519Signature2020';
-const {match, nonMatch} = filterByTag({issuerTags: [tag]});
+const {match, nonMatch} = filterByTag({tags: [tag], property: 'issuers'});
 const should = chai.should();
 const bs58 = /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/;
 
@@ -45,11 +45,11 @@ describe('Ed25519Signature2020 (create)', function() {
             issuer => issuer.tags.has('Ed25519Signature2020'));
           verifier = implementation.verifiers.find(
             verifier => verifier.tags.has('Ed25519Signature2020'));
-          const {issuer: {id: issuerId, options}} = issuer;
+          const {settings: {id: issuerId, options}} = issuer;
           const body = {credential: klona(validVc), options};
           body.credential.id = `urn:uuid:${uuidv4()}`;
           body.credential.issuer = issuerId;
-          const {data} = await issuer.issue({body});
+          const {data} = await issuer.post({json: body});
           issuedVc = data;
           const {proof} = issuedVc || {};
           proofs = Array.isArray(proof) ? proof : [proof];
@@ -122,7 +122,7 @@ describe('Ed25519Signature2020 (create)', function() {
             };
             should.exist(verifier, 'Expected implementation to have a VC ' +
               'HTTP API compatible verifier.');
-            const {result, error} = await verifier.verify({body: {
+            const {result, error} = await verifier.post({json: {
               verifiableCredential: issuedVc,
               options: {checks: ['proof']}
             }});

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -14,7 +14,10 @@ const {bs58Decode, bs58Encode} = require('./helpers');
 const {klona} = require('klona');
 
 // only use implementations with `Ed25519 2020` verifiers.
-const {match, nonMatch} = filterByTag({verifierTags: ['Ed25519Signature2020']});
+const {match, nonMatch} = filterByTag({
+  tags: ['Ed25519Signature2020'],
+  property: 'verifiers'
+});
 
 describe('Ed25519Signature2020 (verify)', function() {
   describe('Data Integrity (verifier)', function() {

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -13,10 +13,10 @@ const should = chai.should();
 // only use implementations with `Ed25519 2020` issuers.
 const {
   match: issuerMatches
-} = filterByTag({issuerTags: ['Ed25519Signature2020']});
+} = filterByTag({tags: ['Ed25519Signature2020'], property: 'issuers'});
 const {
   match: verifierMatches
-} = filterByTag({issuerTags: ['VC-API']});
+} = filterByTag({tags: ['VC-API'], property: 'verifiers'});
 
 describe('Ed25519Signature2020 (interop)', function() {
   // this will tell the report
@@ -31,11 +31,11 @@ describe('Ed25519Signature2020 (interop)', function() {
     before(async function() {
       const issuer = issuers.find(issuer =>
         issuer.tags.has('Ed25519Signature2020'));
-      const {issuer: {id: issuerId, options}} = issuer;
+      const {settings: {id: issuerId, options}} = issuer;
       const body = {credential: klona(validVc), options};
       body.credential.id = `urn:uuid:${uuidv4()}`;
       body.credential.issuer = issuerId;
-      const {data} = await issuer.issue({body});
+      const {data} = await issuer.post({json: body});
       issuedVc = data;
     });
     for(const [verifierName, {verifiers}] of verifierMatches) {
@@ -49,7 +49,7 @@ describe('Ed25519Signature2020 (interop)', function() {
             checks: ['proof']
           }
         };
-        const {result, error} = await verifier.verify({body});
+        const {result, error} = await verifier.post({json: body});
         should.not.exist(error, 'Expected verifier to not error.');
         should.exist(result, 'Expected result from verifier.');
         should.exist(result.status, 'Expected verifier to return an HTTP' +

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -46,7 +46,7 @@ const verificationFail = async ({credential, verifier}) => {
       checks: ['proof']
     }
   };
-  const {result, error} = await verifier.verify({body});
+  const {result, error} = await verifier.post({json: body});
   should.not.exist(result, 'Expected no result from verifier.');
   should.exist(error, 'Expected verifier to error.');
   should.exist(error.status, 'Expected verifier to return an HTTP Status code');
@@ -63,7 +63,7 @@ const verificationSuccess = async ({credential, verifier}) => {
       checks: ['proof']
     }
   };
-  const {result, error} = await verifier.verify({body});
+  const {result, error} = await verifier.post({json: body});
   should.exist(result, 'Expected a result from verifier.');
   should.not.exist(error, 'Expected verifier to not error.');
   should.exist(result.status,


### PR DESCRIPTION
https://github.com/w3c-ccg/vc-api-test-suite-implementations/pull/32

Removes `issuer.issue` in favor of `issuer.post`